### PR TITLE
Add interactive certificate site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Meus Certificados</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Meus Certificados</h1>
+  </header>
+
+  <main>
+    <section id="form-section">
+      <h2>Adicionar certificado</h2>
+      <form id="certificate-form">
+        <input type="text" id="cert-name" placeholder="Nome do certificado" required />
+        <input type="url" id="cert-url" placeholder="URL do certificado" required />
+        <button type="submit">Adicionar</button>
+      </form>
+    </section>
+
+    <section id="list-section">
+      <h2>Lista de certificados</h2>
+      <ul id="certificate-list"></ul>
+    </section>
+  </main>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,33 @@
+const list = document.getElementById('certificate-list');
+const form = document.getElementById('certificate-form');
+const nameInput = document.getElementById('cert-name');
+const urlInput = document.getElementById('cert-url');
+
+let certificates = JSON.parse(localStorage.getItem('certificates')) || [];
+
+function render() {
+  list.innerHTML = '';
+  certificates.forEach((cert) => {
+    const li = document.createElement('li');
+    const link = document.createElement('a');
+    link.href = cert.url;
+    link.textContent = cert.name;
+    link.target = '_blank';
+    li.appendChild(link);
+    list.appendChild(li);
+  });
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const cert = {
+    name: nameInput.value.trim(),
+    url: urlInput.value.trim(),
+  };
+  certificates.push(cert);
+  localStorage.setItem('certificates', JSON.stringify(certificates));
+  render();
+  form.reset();
+});
+
+render();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,90 @@
+:root {
+  --primary: #4a148c;
+  --secondary: #7c4dff;
+  --background: #f3e5f5;
+  --text: #212121;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: 'Arial', sans-serif;
+}
+
+body {
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  text-align: center;
+  padding: 2rem;
+  color: #fff;
+}
+
+main {
+  background: var(--background);
+  flex: 1;
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+h2 {
+  margin-bottom: 1rem;
+}
+
+#certificate-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+#certificate-form input {
+  flex: 1 1 300px;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--primary);
+  border-radius: 8px;
+}
+
+#certificate-form button {
+  padding: 0.5rem 1.5rem;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+#certificate-form button:hover {
+  background: var(--secondary);
+}
+
+#certificate-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+#certificate-list li {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#certificate-list a {
+  text-decoration: none;
+  color: var(--primary);
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- build modern certificate page with form to add new entries
- style layout with gradient background and responsive grid
- persist certificates using browser local storage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ba20a908330b398bdbd034906f3