### PR TITLE
Remove Google login and store certificates locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,27 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Meus Certificados</title>
   <link rel="stylesheet" href="styles.css" />
-  <script src="https://accounts.google.com/gsi/client" async defer></script>
-  <script src="https://apis.google.com/js/api.js" async defer></script>
 </head>
 <body>
   <header>
     <h1>Meus Certificados</h1>
-    <div id="auth-area">
-      <div id="g_id_onload"
-           data-client_id="YOUR_GOOGLE_CLIENT_ID"
-           data-callback="handleCredentialResponse"></div>
-      <div class="g_id_signin" data-type="standard" data-size="medium"></div>
-      <button id="sign-out" hidden>Sair</button>
-    </div>
   </header>
 
   <main>
-    <section id="login-prompt" hidden>
-      <p>Entre com sua conta Google para gerenciar seus certificados.</p>
-    </section>
-
-    <section id="form-section" hidden>
+    <section id="form-section">
       <h2>Adicionar certificado</h2>
       <form id="certificate-form">
         <input type="text" id="cert-name" placeholder="Nome do certificado" required />
@@ -34,7 +21,7 @@
       </form>
     </section>
 
-    <section id="list-section" hidden>
+    <section id="list-section">
       <h2>Lista de certificados</h2>
       <ul id="certificate-list"></ul>
     </section>

--- a/script.js
+++ b/script.js
@@ -2,130 +2,8 @@ const list = document.getElementById('certificate-list');
 const form = document.getElementById('certificate-form');
 const nameInput = document.getElementById('cert-name');
 const urlInput = document.getElementById('cert-url');
-const formSection = document.getElementById('form-section');
-const listSection = document.getElementById('list-section');
-const loginPrompt = document.getElementById('login-prompt');
-const signOutBtn = document.getElementById('sign-out');
 
-let certificates = [];
-let user = null;
-let driveFileId = null;
-
-loginPrompt.hidden = false;
-
-function handleCredentialResponse(response) {
-  const data = parseJwt(response.credential);
-  user = data;
-  signOutBtn.hidden = false;
-  formSection.hidden = false;
-  listSection.hidden = false;
-  loginPrompt.hidden = true;
-  gapi.load('client', initGapi);
-}
-
-function parseJwt(token) {
-  return JSON.parse(atob(token.split('.')[1]));
-}
-
-async function initGapi() {
-  try {
-    await gapi.client.init({
-      apiKey: 'YOUR_API_KEY',
-      discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
-    });
-  } catch (e) {
-    console.error('Falha ao inicializar gapi', e);
-  }
-  await loadCertificates();
-}
-
-async function loadCertificates() {
-  try {
-    const response = await gapi.client.drive.files.list({
-      q: "name='certificates.json' and mimeType='application/json' and trashed=false",
-      fields: 'files(id, name)',
-      spaces: 'drive',
-    });
-    if (response.result.files && response.result.files.length > 0) {
-      driveFileId = response.result.files[0].id;
-      const file = await gapi.client.drive.files.get({
-        fileId: driveFileId,
-        alt: 'media',
-      });
-      certificates = JSON.parse(file.body);
-    } else {
-      certificates = [];
-    }
-  } catch (e) {
-    certificates = JSON.parse(localStorage.getItem(`certificates-${user.sub}`)) || [];
-  }
-  render();
-}
-
-async function saveCertificates() {
-  try {
-    const content = JSON.stringify(certificates);
-    const boundary = 'foo_bar_baz';
-    const delimiter = `\r\n--${boundary}\r\n`;
-    const closeDelim = `\r\n--${boundary}--`;
-
-    const metadata = {
-      name: 'certificates.json',
-      mimeType: 'application/json',
-    };
-
-    const multipartRequestBody =
-      delimiter + 'Content-Type: application/json\r\n\r\n' +
-      JSON.stringify(metadata) +
-      delimiter + 'Content-Type: application/json\r\n\r\n' +
-      content +
-      closeDelim;
-
-    if (driveFileId) {
-      await gapi.client.request({
-        path: `/upload/drive/v3/files/${driveFileId}`,
-        method: 'PATCH',
-        params: { uploadType: 'multipart' },
-        headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
-        body: multipartRequestBody,
-      });
-    } else {
-      const res = await gapi.client.request({
-        path: '/upload/drive/v3/files',
-        method: 'POST',
-        params: { uploadType: 'multipart' },
-        headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
-        body: multipartRequestBody,
-      });
-      driveFileId = res.result.id;
-    }
-  } catch (e) {
-    localStorage.setItem(`certificates-${user.sub}`, JSON.stringify(certificates));
-  }
-}
-
-form.addEventListener('submit', (e) => {
-  e.preventDefault();
-  const cert = {
-    name: nameInput.value.trim(),
-    url: urlInput.value.trim(),
-  };
-  certificates.push(cert);
-  render();
-  saveCertificates();
-  form.reset();
-});
-
-signOutBtn.addEventListener('click', () => {
-  user = null;
-  certificates = [];
-  driveFileId = null;
-  signOutBtn.hidden = true;
-  formSection.hidden = true;
-  listSection.hidden = true;
-  loginPrompt.hidden = false;
-  list.innerHTML = '';
-});
+let certificates = JSON.parse(localStorage.getItem('certificates')) || [];
 
 function render() {
   list.innerHTML = '';
@@ -140,5 +18,20 @@ function render() {
   });
 }
 
-// Expose handler globally
-window.handleCredentialResponse = handleCredentialResponse;
+function saveCertificates() {
+  localStorage.setItem('certificates', JSON.stringify(certificates));
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const cert = {
+    name: nameInput.value.trim(),
+    url: urlInput.value.trim(),
+  };
+  certificates.push(cert);
+  render();
+  saveCertificates();
+  form.reset();
+});
+
+render();

--- a/styles.css
+++ b/styles.css
@@ -92,22 +92,3 @@ h2 {
   font-weight: bold;
 }
 
-#auth-area {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-#sign-out {
-  padding: 0.4rem 1rem;
-  background: var(--primary);
-  color: #000;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: opacity 0.3s;
-}
-
-#sign-out:hover {
-  opacity: 0.85;
-}


### PR DESCRIPTION
## Summary
- Remove Google sign-in scripts and UI from index
- Store certificates using localStorage with simplified script
- Drop unused authentication-related styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2de6533083308a78542df8eea8b7